### PR TITLE
feat(hooks): add useFocusCycling custom hook

### DIFF
--- a/src/hooks/useFocusCycling.ts
+++ b/src/hooks/useFocusCycling.ts
@@ -1,0 +1,56 @@
+import { useEffect } from 'react';
+
+/**
+ * useFocusCycling
+ *
+ * A custom hook to enable cycling focus through focusable elements within a container.
+ *
+ * @param {React.RefObject<HTMLElement>} containerRef - The ref of the container element.
+ * @param {string[]} [customSelectors=[]] - Additional selectors for custom focusable elements.
+ */
+const useFocusCycling = (
+    containerRef: React.RefObject<HTMLElement>,
+    customSelectors: string[] = []
+) => {
+    useEffect(() => {
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (!containerRef.current) return;
+
+            const defaultSelectors = [
+                'a',
+                'button',
+                'input',
+                'textarea',
+                'select',
+                'details',
+                '[tabindex]:not([tabindex="-1"])'
+            ];
+
+            const selectors = defaultSelectors.concat(customSelectors).join(',');
+            const focusableElements = Array.from(
+                containerRef.current.querySelectorAll<HTMLElement>(selectors)
+            ).filter((el) => !el.hasAttribute('disabled'));
+
+            const currentIndex = focusableElements.indexOf(document.activeElement as HTMLElement);
+
+            if (event.key === 'Tab') {
+                if (event.shiftKey && currentIndex === 0) {
+                    focusableElements[focusableElements.length - 1].focus();
+                    event.preventDefault();
+                } else if (!event.shiftKey && currentIndex === focusableElements.length - 1) {
+                    focusableElements[0].focus();
+                    event.preventDefault();
+                }
+            }
+        };
+
+        const container = containerRef.current;
+        container?.addEventListener('keydown', handleKeyDown);
+
+        return () => {
+            container?.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [containerRef, customSelectors]);
+};
+
+export default useFocusCycling;


### PR DESCRIPTION
Introduce useFocusCycling to manage cycling of focus among focusable elements within a container. This hook listens for the 'Tab' key press and cycles the focus correctly, supporting additional custom selectors.