### PR TITLE
feat(config): enable Google Analytics tracking

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -136,13 +136,13 @@ const config: Config = {
         language: 'en',
       },
     ],
-    // [
-    //   '@docusaurus/plugin-google-gtag',
-    //   {
-    //     trackingID: '',
-    //     anonymizeIP: true,
-    //   },
-    // ],
+    [
+      '@docusaurus/plugin-google-gtag',
+      {
+        trackingID: 'G-090P1G1DYN',
+        anonymizeIP: true,
+      },
+    ],
     // '@stackql/docusaurus-plugin-structured-data',
   ],
 };


### PR DESCRIPTION
Uncommented and configured Google Analytics plugin with tracking ID 'G-090P1G1DYN'. This will enable tracking and anonymize IP addresses for better privacy compliance.