### PR TITLE
refactor: update build output directory and import paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules/
-lib/
+dist/
 coverage
 reports
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,17 @@
 // Components
-export { Focusable } from 'components/Focusable';
-export { FocusRing } from 'components/FocusRing';
-export { FocusTrap } from 'components/FocusTrap';
-export { SkipLink } from 'components/SkipLink';
+export { Focusable } from '@/components/Focusable';
+export { FocusRing } from '@/components/FocusRing';
+export { FocusTrap } from '@/components/FocusTrap';
+export { SkipLink } from '@/components/SkipLink';
 
 
 // Context
-export { FocusProvider, useFocusContext } from 'context/FocusContext';
+export { FocusProvider, useFocusContext } from '@/context/FocusContext';
 
 
 // Hooks
-export { useFocusOnMount } from 'hooks/useFocusOnMount';
-export { useFocusOrder } from 'hooks/useFocusOrder';
-export { useFocusReturn } from 'hooks/useFocusReturn';
-export { useFocusVisible } from 'hooks/useFocusVisible';
-export { useFocusWithin } from 'hooks/useFocusWithin';
+export { useFocusOnMount } from '@/hooks/useFocusOnMount';
+export { useFocusOrder } from '@/hooks/useFocusOrder';
+export { useFocusReturn } from '@/hooks/useFocusReturn';
+export { useFocusVisible } from '@/hooks/useFocusVisible';
+export { useFocusWithin } from '@/hooks/useFocusWithin';

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -7,7 +7,7 @@ const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 module.exports = {
     entry: './src/index.ts',
     output: {
-        path: path.resolve(__dirname, 'lib'),
+        path: path.resolve(__dirname, 'dist'),
         filename: 'index.js',
         library: {
             type: 'module',
@@ -66,11 +66,11 @@ module.exports = {
     resolve: {
         extensions: ['.ts', '.tsx', '.js', '.jsx'],
         alias: {
-            components: path.resolve(__dirname, 'src/components/'),
-            hooks: path.resolve(__dirname, 'src/hooks/'),
-            utils: path.resolve(__dirname, 'src/utils/'),
-            styles: path.resolve(__dirname, 'src/styles/'),
-            context: path.resolve(__dirname, 'src/context/'),
+            '@/components': path.resolve(__dirname, 'src/components/'),
+            '@/hooks': path.resolve(__dirname, 'src/hooks/'),
+            '@/utils': path.resolve(__dirname, 'src/utils/'),
+            '@/styles': path.resolve(__dirname, 'src/styles/'),
+            '@/context': path.resolve(__dirname, 'src/context/'),
         },
     },
 };


### PR DESCRIPTION
Changed build output directory from 'lib' to 'dist' for consistency. Updated import paths to use '@/' alias for better readability and maintenance.