### PR TITLE
refactor: update import paths for consistency

### DIFF
--- a/src/hooks/useFocusReturn.ts
+++ b/src/hooks/useFocusReturn.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 
-import { isBrowser } from 'utils/environment';
-import { isFocusable } from 'utils/focusUtils';
+import { isBrowser } from '@/utils/environment';
+import { isFocusable } from '@/utils/focusUtils';
 
 /**
  * useFocusReturn

--- a/src/hooks/useFocusWithin.ts
+++ b/src/hooks/useFocusWithin.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, RefObject } from 'react';
-import { isBrowser } from 'utils/environment';
+
+import { isBrowser } from '@/utils/environment';
 
 /**
  * useFocusWithin


### PR DESCRIPTION
Change import paths to use absolute imports in useFocusWithin and useFocusReturn hooks. This improves maintainability and consistency across the codebase.